### PR TITLE
Fixes ajdavis/mongo-mockup-db#3

### DIFF
--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -1577,7 +1577,7 @@ def mock_server_receive(sock, length):
     """Receive `length` bytes from a socket object."""
     msg = b''
     while length:
-        if select.select([sock.fileno()], [], [], 1):
+        if select.select([sock.fileno()], [], [], 1)[0]:
             try:
                 chunk = sock.recv(length)
                 if chunk == b'':


### PR DESCRIPTION
Using the return value of select directly is truthy even when no file descriptors are returned (`([], [], [])`), which can cause `sock.recv` to be called when no data is available, causing threads to hang.