### PR TITLE
Handle AssertionErrors from requests better

### DIFF
--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -1500,6 +1500,9 @@ class MockupDB(object):
                     break
                 else:
                     raise
+            except AssertionError:
+                # We got bad data. Bail to avoid leaking resources
+                break
 
         self._log('disconnected: %s:%d' % client_addr)
         client.close()


### PR DESCRIPTION
Related to my issue in #7 when I was getting `AssertionErrors`, the client was also failing to close properly (it totally hangs) and giving a `ResourceWarning` for the unclosed socket that had thrown an exception.

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1035, in wrapper
    return meth(self, *args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1480, in _server_loop
    request = mock_server_receive_request(client, self)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1580, in mock_server_receive_request
    return OPCODES[opcode].unpack(msg_bytes, client, server, request_id)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 553, in unpack
    assert len(docs) == 1
AssertionError

/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py:1451: ResourceWarning: unclosed <socket.socket fd=30, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 65311), raddr=('127.0.0.1', 65313)>
  client, client_addr = self._listening_sock.accept()
2017-10-18 23:53:55,774 Georges-MBP-2 ERROR /Users/george/Sites/iproov/common_lib/mongo_reconnect_decorator.py:30 AutoReconnect retry to Mongo as AutoReconnect exception found.
Exception in thread Thread-9:
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1035, in wrapper
    return meth(self, *args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1480, in _server_loop
    request = mock_server_receive_request(client, self)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 1580, in mock_server_receive_request
    return OPCODES[opcode].unpack(msg_bytes, client, server, request_id)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/mockupdb/__init__.py", line 553, in unpack
    assert len(docs) == 1
AssertionError
```

This patch catches the error and closes the thread. Inside pymongo an `AutoReconnect` exception is thrown. I guess it might be useful to add some logging about the why the `AssertionError` is being thrown but I'll leave that decision upto you? It's easy to add I guess if you want it :)