### PR TITLE
PYTHON-1377 Implement OP_MSG parsing and responses in MockupDB

### DIFF
--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -621,7 +621,7 @@ class OpMsg(Request):
             return list(self.docs[0])[0]
 
     def _replies(self, *args, **kwargs):
-        reply = OpMsgReply(*args, **kwargs)
+        reply = make_op_msg_reply(*args, **kwargs)
         if not reply.docs:
             reply.docs = [{'ok': 1}]
         else:
@@ -1776,6 +1776,22 @@ def make_reply(*args, **kwargs):
         return args[0]
 
     return OpReply(*args, **kwargs)
+
+
+def make_op_msg_reply(*args, **kwargs):
+    # Error we might raise.
+    if args and isinstance(args[0], OpMsgReply):
+        if args[1:] or kwargs:
+            raise_args_err("can't interpret args")
+        return args[0]
+
+    # HACK: tests should not specify OpReply when the maxWireVersion>=6
+    if args and isinstance(args[0], OpReply):
+        if args[1:] or kwargs:
+            raise_args_err("can't interpret args")
+        return OpMsgReply(args[0].doc)
+
+    return OpMsgReply(*args, **kwargs)
 
 
 def unprefixed(bson_str):

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -1786,16 +1786,10 @@ def make_reply(*args, **kwargs):
 
 def make_op_msg_reply(*args, **kwargs):
     # Error we might raise.
-    if args and isinstance(args[0], OpMsgReply):
+    if args and isinstance(args[0], (OpReply, OpMsgReply)):
         if args[1:] or kwargs:
             raise_args_err("can't interpret args")
         return args[0]
-
-    # HACK: tests should not specify OpReply when the maxWireVersion>=6
-    if args and isinstance(args[0], OpReply):
-        if args[1:] or kwargs:
-            raise_args_err("can't interpret args")
-        return OpMsgReply(args[0].doc)
 
     return OpMsgReply(*args, **kwargs)
 

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -1018,16 +1018,10 @@ class OpMsgReply(Reply):
         self.doc.update(*args, **kwargs)
 
     def reply_bytes(self, request):
-        """Take a `Request` and return an OP_REPLY message as bytes."""
+        """Take a `Request` and return an OP_MSG message as bytes."""
         flags = struct.pack("<I", self._flags)
         payload_type = struct.pack("<b", 0)
-        if self._docs:
-            doc = self.doc
-        else:
-            # Default to a generic ok command response.
-            doc = {"ok": 1}
-
-        payload_data = _bson.BSON.encode(doc)
+        payload_data = _bson.BSON.encode(self.doc)
         data = b''.join([flags, payload_type, payload_data])
 
         reply_id = random.randint(0, 1000000)

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -594,15 +594,14 @@ class OpMsg(Request):
 
     def __init__(self, *args, **kwargs):
         super(OpMsg, self).__init__(*args, **kwargs)
-        self._read_preference = self.doc.get('$readPreference')
         if len(self._docs) > 1:
             raise_args_err('OpMsg too many documents', ValueError)
 
     @property
     def slave_ok(self):
         """True if this OpMsg can read from a secondary."""
-        return (self._read_preference and
-                self._read_preference.get('mode') != 'primary')
+        read_preference = self.doc.get('$readPreference')
+        return read_preference and read_preference.get('mode') != 'primary'
 
     slave_okay = slave_ok
     """Synonym for `.slave_ok`."""

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -266,7 +266,7 @@ REPLY_FLAGS = OrderedDict([
 
 OP_MSG_FLAGS = OrderedDict([
     ('checksumPresent', 1),
-    ('moreToCome', 4)])
+    ('moreToCome', 2)])
 
 _UNPACK_INT = struct.Struct("<i").unpack
 _UNPACK_LONG = struct.Struct("<q").unpack
@@ -594,8 +594,19 @@ class OpMsg(Request):
 
     def __init__(self, *args, **kwargs):
         super(OpMsg, self).__init__(*args, **kwargs)
+        self._database = self.doc['$db']
+        self._read_preference = self.doc.get('$readPreference')
         if len(self._docs) > 1:
             raise_args_err('OpMsg too many documents', ValueError)
+
+    @property
+    def slave_ok(self):
+        """True if this OpMsg can read from a secondary."""
+        return (self._read_preference and
+                self._read_preference.get('mode') != 'primary')
+
+    slave_okay = slave_ok
+    """Synonym for `.slave_ok`."""
 
     @property
     def command_name(self):

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -980,7 +980,7 @@ class OpMsgReply(Reply):
     """A OP_MSG reply from `MockupDB` to the client."""
     def __init__(self, *args, **kwargs):
         super(OpMsgReply, self).__init__(*args, **kwargs)
-        assert len(self._docs) == 1, 'OpMsgReply must have one document'
+        assert len(self._docs) <= 1, 'OpMsgReply can only have one document'
 
     @property
     def docs(self):
@@ -1007,7 +1007,13 @@ class OpMsgReply(Reply):
         """Take a `Request` and return an OP_REPLY message as bytes."""
         flags = struct.pack("<I", self._flags)
         payload_type = struct.pack("<b", 0)
-        payload_data = _bson.BSON.encode(self.doc)
+        if self._docs:
+            doc = self.doc
+        else:
+            # Default to a generic ok command response.
+            doc = {"ok": 1}
+
+        payload_data = _bson.BSON.encode(doc)
         data = b''.join([flags, payload_type, payload_data])
 
         reply_id = random.randint(0, 1000000)

--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -594,7 +594,6 @@ class OpMsg(Request):
 
     def __init__(self, *args, **kwargs):
         super(OpMsg, self).__init__(*args, **kwargs)
-        self._database = self.doc['$db']
         self._read_preference = self.doc.get('$readPreference')
         if len(self._docs) > 1:
             raise_args_err('OpMsg too many documents', ValueError)

--- a/tests/test_mockupdb.py
+++ b/tests/test_mockupdb.py
@@ -24,7 +24,7 @@ from bson.codec_options import CodecOptions
 from pymongo import MongoClient, message, WriteConcern
 
 from mockupdb import (_bson as mockup_bson, go, going,
-                      Command, Matcher, MockupDB, Request,
+                      Command, CommandBase, Matcher, MockupDB, Request,
                       OpDelete, OpInsert, OpMsg, OpQuery, OpUpdate,
                       DELETE_FLAGS, INSERT_FLAGS, UPDATE_FLAGS, QUERY_FLAGS)
 from tests import unittest  # unittest2 on Python 2.6.
@@ -243,7 +243,7 @@ class TestAutoresponds(unittest.TestCase):
     def test_autoresponds_case_insensitive(self):
         server = MockupDB(auto_ismaster=True)
         # Little M. Note this is only case-insensitive because it's a Command.
-        server.autoresponds(OpMsg('fooBar'), foo='bar')
+        server.autoresponds(CommandBase('fooBar'), foo='bar')
         server.run()
         response = MongoClient(server.uri).admin.command('Foobar')
         self.assertEqual('bar', response['foo'])

--- a/tests/test_mockupdb.py
+++ b/tests/test_mockupdb.py
@@ -25,7 +25,7 @@ from pymongo import MongoClient, message, WriteConcern
 
 from mockupdb import (_bson as mockup_bson, go, going,
                       Command, Matcher, MockupDB, Request,
-                      OpDelete, OpInsert, OpQuery, OpUpdate,
+                      OpDelete, OpInsert, OpMsg, OpQuery, OpUpdate,
                       DELETE_FLAGS, INSERT_FLAGS, UPDATE_FLAGS, QUERY_FLAGS)
 from tests import unittest  # unittest2 on Python 2.6.
 
@@ -243,7 +243,7 @@ class TestAutoresponds(unittest.TestCase):
     def test_autoresponds_case_insensitive(self):
         server = MockupDB(auto_ismaster=True)
         # Little M. Note this is only case-insensitive because it's a Command.
-        server.autoresponds(Command('fooBar'), foo='bar')
+        server.autoresponds(OpMsg('fooBar'), foo='bar')
         server.run()
         response = MongoClient(server.uri).admin.command('Foobar')
         self.assertEqual('bar', response['foo'])


### PR DESCRIPTION
This depends on the PyMongo changes in [PYTHON-1329](https://jira.mongodb.org/browse/PYTHON-1329).

The related pymongo-mockup-tests change depends on this.