### PR TITLE
Test with Python 3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ branches:
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27-test
-    - python: 3.4
-      env: TOXENV=py34-test
-    - python: 3.4
-      env: TOXENV=py34-docs
-    - python: 3.4
-      env: TOXENV=py34-doctest
+    - python: 2.6
+      env: TOXENV=py26-test
+    - python: 3.6
+      env: TOXENV=py36-test
+    - python: 3.6
+      env: TOXENV=py36-docs
+    - python: 3.6
+      env: TOXENV=py36-doctest
 
 install:
   - pip install -U tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ branches:
 
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26-test
+    - python: 2.7
+      env: TOXENV=py27-test
     - python: 3.6
       env: TOXENV=py36-test
     - python: 3.6


### PR DESCRIPTION
Attempt to leapfrog over a setuptools issue encountered when building
the docs with Python 3.4 on Travis