### PR TITLE
Workaround Python 3.4 pip failure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
       env: TOXENV=py36-doctest
 
 install:
+  # Upgrade pip to avoid issues installing tox on Python 3.4:
+  # https://github.com/pypa/setuptools/issues/951
+  - pip install -U pip
   - pip install -U tox
 
 script:


### PR DESCRIPTION
This change should workaround the Python 3.4 pip failures we're seeing in Travis:
```
$ source ~/virtualenv/python3.4/bin/activate
$ python --version
Python 3.4.6
$ pip --version
pip 9.0.1 from /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (python 3.4)
4.48s$ pip install -U tox
Collecting tox
  Downloading https://files.pythonhosted.org/packages/a7/0c/ed234b83d2c4fcef1cfccf97371183d51dafae62e64334de34d0a6333114/tox-3.14.0-py2.py3-none-any.whl (80kB)
    100% |████████████████████████████████| 81kB 3.0MB/s 
Collecting packaging>=14 (from tox)
  Downloading https://files.pythonhosted.org/packages/cf/94/9672c2d4b126e74c4496c6b3c58a8b51d6419267be9e70660ba23374c875/packaging-19.2-py2.py3-none-any.whl
Collecting six<2,>=1.0.0 (from tox)
  Downloading https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting virtualenv>=14.0.0 (from tox)
  Downloading https://files.pythonhosted.org/packages/8b/12/8d4f45b8962b03ac9efefe5ed5053f6b29334d83e438b4fe379d21c0cb8e/virtualenv-16.7.5-py2.py3-none-any.whl (3.3MB)
    100% |████████████████████████████████| 3.3MB 439kB/s 
Collecting importlib-metadata<1,>=0.12; python_version < "3.8" (from tox)
  Downloading https://files.pythonhosted.org/packages/f6/d2/40b3fa882147719744e6aa50ac39cf7a22a913cbcba86a0371176c425a3b/importlib_metadata-0.23-py2.py3-none-any.whl
Collecting pluggy<1,>=0.12.0 (from tox)
  Downloading https://files.pythonhosted.org/packages/92/c7/48439f7d5fd6bddb4c04b850bb862b42e3e2b98570040dfaf68aedd8114b/pluggy-0.13.0-py2.py3-none-any.whl
Collecting filelock<4,>=3.0.0 (from tox)
  Downloading https://files.pythonhosted.org/packages/93/83/71a2ee6158bb9f39a90c0dea1637f81d5eef866e188e1971a1b1ab01a35a/filelock-3.0.12-py3-none-any.whl
Collecting py<2,>=1.4.17 (from tox)
  Downloading https://files.pythonhosted.org/packages/76/bc/394ad449851729244a97857ee14d7cba61ddb268dce3db538ba2f2ba1f0f/py-1.8.0-py2.py3-none-any.whl (83kB)
    100% |████████████████████████████████| 92kB 10.2MB/s 
Collecting toml>=0.9.4 (from tox)
  Downloading https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl
Collecting pyparsing>=2.0.2 (from packaging>=14->tox)
  Downloading https://files.pythonhosted.org/packages/11/fa/0160cd525c62d7abd076a070ff02b2b94de589f1a9789774f17d7c54058e/pyparsing-2.4.2-py2.py3-none-any.whl (65kB)
    100% |████████████████████████████████| 71kB 9.4MB/s 
Collecting zipp>=0.5 (from importlib-metadata<1,>=0.12; python_version < "3.8"->tox)
  Downloading https://files.pythonhosted.org/packages/74/3d/1ee25a26411ba0401b43c6376d2316a71addcc72ef8690b101b4ea56d76a/zipp-0.6.0-py2.py3-none-any.whl
Collecting pathlib2; python_version == "3.4.*" or python_version < "3" (from importlib-metadata<1,>=0.12; python_version < "3.8"->tox)
  Downloading https://files.pythonhosted.org/packages/e9/45/9c82d3666af4ef9f221cbb954e1d77ddbb513faf552aea6df5f37f1a4859/pathlib2-2.3.5-py2.py3-none-any.whl
Collecting more-itertools (from zipp>=0.5->importlib-metadata<1,>=0.12; python_version < "3.8"->tox)
  Downloading https://files.pythonhosted.org/packages/45/dc/3241eef99eb45f1def35cf93af35d1cf9ef4c0991792583b8f33ea41b092/more_itertools-7.2.0-py3-none-any.whl (57kB)
    100% |████████████████████████████████| 61kB 9.4MB/s 
Collecting scandir; python_version < "3.5" (from pathlib2; python_version == "3.4.*" or python_version < "3"->importlib-metadata<1,>=0.12; python_version < "3.8"->tox)
  Downloading https://files.pythonhosted.org/packages/df/f5/9c052db7bd54d0cbf1bc0bb6554362bba1012d03e5888950a4f5c5dadc4e/scandir-1.10.0.tar.gz
Building wheels for collected packages: scandir
  Running setup.py bdist_wheel for scandir ... done
  Stored in directory: /home/travis/.cache/pip/wheels/91/95/75/19c98a91239878abbc7c59970abd3b4e0438a7dd5b61778335
Successfully built scandir
Installing collected packages: six, pyparsing, packaging, virtualenv, more-itertools, zipp, scandir, pathlib2, importlib-metadata, pluggy, filelock, py, toml, tox
  Found existing installation: six 1.10.0
    Uninstalling six-1.10.0:
      Successfully uninstalled six-1.10.0
  Rolling back uninstall of six
Exception:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2813, in _dep_map
    return self.__dep_map
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2624, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2804, in _parsed_pkg_info
    return self._pkg_info
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2624, in __getattr__
    raise AttributeError(attr)
AttributeError: _pkg_info
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/commands/install.py", line 342, in run
    prefix=options.prefix_path,
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/req/req_set.py", line 784, in install
    **kwargs
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/req/req_install.py", line 851, in install
    self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/req/req_install.py", line 1064, in move_wheel_files
    isolated=self.isolated,
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/wheel.py", line 247, in move_wheel_files
    prefix=prefix,
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pip/locations.py", line 140, in distutils_scheme
    d = Distribution(dist_args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/setuptools/dist.py", line 321, in __init__
    _Distribution.__init__(self, attrs)
  File "/opt/python/3.4.6/lib/python3.4/distutils/dist.py", line 280, in __init__
    self.finalize_options()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/setuptools/dist.py", line 389, in finalize_options
    ep.require(installer=self.fetch_build_egg)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2324, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 862, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2568, in requires
    dm = self._dep_map
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2815, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2824, in _compute_dependencies
    for req in self._parsed_pkg_info.get_all('Requires-Dist') or []:
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2806, in _parsed_pkg_info
    metadata = self.get_metadata(self.PKG_INFO)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 1468, in get_metadata
    value = self._get(self._fn(self.egg_info, name))
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 1577, in _get
    with open(path, 'rb') as stream:
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/six-1.10.0.dist-info/METADATA'
The command "pip install -U tox" failed and exited with 2 during .
```
https://travis-ci.org/ajdavis/mongo-mockup-db/jobs/592835019

See:
https://github.com/pypa/setuptools/issues/951