### PR TITLE
PYTHON-2720 Fix OP_MSG exhaustAllowed flag

### DIFF
--- a/mockupdb/__init__.py
+++ b/mockupdb/__init__.py
@@ -269,9 +269,9 @@ REPLY_FLAGS = OrderedDict([
     ('QueryFailure', 2)])
 
 OP_MSG_FLAGS = OrderedDict([
-    ('checksumPresent', 1),
-    ('moreToCome', 2),
-    ('exhaustAllowed', 16)])
+    ('checksumPresent', 1 << 0),
+    ('moreToCome', 1 << 1),
+    ('exhaustAllowed', 1 << 16)])
 
 _ALL_OP_MSG_FLAGS = functools.reduce(operator.or_, OP_MSG_FLAGS.values())
 


### PR DESCRIPTION
exhaustAllowed is the 16th bit, not 16. See: https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst#flagbits 

Found while working on https://jira.mongodb.org/browse/PYTHON-2720